### PR TITLE
don't require Sync trait for job function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub use uuid::Uuid;
 /// A schedulable `Job`.
 pub struct Job<'a> {
     schedule: Schedule,
-    run: Box<dyn (FnMut()) + Send + Sync + 'a>,
+    run: Box<dyn (FnMut()) + Send + 'a>,
     last_tick: Option<DateTime<Utc>>,
     limit_missed_runs: usize,
     job_id: Uuid,
@@ -85,7 +85,7 @@ impl<'a> Job<'a> {
     where
         T: 'a,
         T: FnMut(),
-        T: FnMut() + Send + Sync,
+        T: FnMut() + Send,
     {
         Job {
             schedule,


### PR DESCRIPTION
What is the reason for the `Sync` trait for the function a job executes?
I understand the need for `Send`, but I don't exactly understand why I need `Sync` here.

`Sync` would be necessary if I want to *share* data between e.g. threads. But this is not really necessary from my perspective.
I want to be able to use `std::sync::mpsc` to regularly send some commands in a `Sender`.
`Sender` implements `Send` but no `Sync`. To use a `Sender` from within the function called from the job I would need to move the necessary variables inside the closure.

example code:
```rust
let command_tx: Sender<String> = ...;
scheduler.add(Job::new("1/10 * * * * *".parse().unwrap(), {
    move || {
        command_tx
            .send("I get executed every 10 seconds!".into())
            .unwrap();
    }
}));
```

without my commit this produces the following error:
```
`std::sync::mpsc::Sender<std::string::String>` cannot be shared between threads safely
```

I might overlook some important part here, but for my example code this worked out fine.