### PR TITLE
Some cleanups and clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "job_scheduler_ng"
-version = "2.0.4"
+version = "2.0.5"
 authors = ["Mathijs van Veluw <black.dex@gmail.com>"]
 description = "A simple cron-like job scheduling library for Rust (Updated since 2022)."
 documentation = "https://docs.rs/job_scheduler_ng/"
@@ -10,12 +10,12 @@ license = "MIT OR Apache-2.0"
 keywords = ["cron", "crontab", "scheduler", "job"]
 categories = ["date-and-time"]
 edition = "2021"
-rust-version = "1.56.1" # Examples need v1.58 to be able to run.
+rust-version = "1.61.0"
 
 [dependencies]
 cron = "0.12.0"
-chrono = { version = "~0.4.20", default-features = false, features = ["clock"] }
+chrono = { version = "~0.4.34", default-features = false, features = ["clock"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-tokio = { version = ">=1.25.0", features = ["macros", "time", "rt-multi-thread"] }
+tokio = { version = ">=1.37", features = ["macros", "time", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ This is a fork which i try to maintain and maybe even improve where needed.
 
 ## Updates
 
+**2024-04-24 (v2.0.5):**
+ - Set MSRV to v1.61.0 to match chrono's v0.4.34 MSRV
+ - Updated dev dependency of tokio to v1.37.0 or higher
+ - Several clippy check added
+ - Fixed all clippy reported items
+ - Set JobScheduler::new() as `const fn`
+ - Updated examples to use a `log` function and always print the current thread id
+ - Added a very simple hash to better differentiate the tokio 5th second example
+
+
 **2023-02-01 (v2.0.4):**
  - Validated uuid v1.3.0 works
  - Used miri to check examples

--- a/examples/simple_job.rs
+++ b/examples/simple_job.rs
@@ -1,24 +1,41 @@
+use core::time::Duration;
 use job_scheduler_ng::{Job, JobScheduler};
-use std::time::Duration;
+use std::time::Instant;
 
 fn main() {
+    const WAIT_SECONDS: u64 = 40;
+
     let mut sched = JobScheduler::new();
 
-    sched.add(Job::new("1/10 * * * * *".parse().unwrap(), || {
-        println!(
-            "{:?} - I get executed every 10 seconds!",
-            chrono::Utc::now()
-        );
+    sched.add(Job::new("0/10 * * * * *".parse().unwrap(), || {
+        log("I get executed every 10th second!");
     }));
 
     sched.add(Job::new("*/4 * * * * *".parse().unwrap(), || {
-        println!("{:?} - I get executed every 4 seconds!", chrono::Utc::now());
+        log("I get executed every 4 seconds!");
     }));
 
-    println!("{:?} - Starting loop", chrono::Utc::now());
+    log(&format!("Run for about {WAIT_SECONDS} seconds!"));
+    log("Starting loop");
+    let start = Instant::now();
     loop {
         sched.tick();
 
         std::thread::sleep(Duration::from_millis(500));
+
+        // Check if we have waited long enough
+        if start.elapsed().as_secs() >= WAIT_SECONDS {
+            break;
+        }
     }
+    log("Finished. Goodby!");
+    std::process::exit(0);
+}
+
+fn log(msg: &str) {
+    println!(
+        "{:?} - {:?} - {msg}",
+        chrono::Utc::now(),
+        std::thread::current().id()
+    );
 }

--- a/examples/simple_job_mpsc.rs
+++ b/examples/simple_job_mpsc.rs
@@ -1,19 +1,18 @@
+use core::time::Duration;
 use job_scheduler_ng::{Job, JobScheduler};
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::time::Duration;
 
 fn main() {
+    const WAIT_SECONDS: u64 = 40;
+
     let mut sched = JobScheduler::new();
 
-    sched.add(Job::new("1/10 * * * * *".parse().unwrap(), || {
-        println!(
-            "{:?} - I get executed every 10 seconds!",
-            chrono::Utc::now()
-        );
+    sched.add(Job::new("0/10 * * * * *".parse().unwrap(), || {
+        log("I get executed every 10th second!");
     }));
 
     sched.add(Job::new("*/4 * * * * *".parse().unwrap(), || {
-        println!("{:?} - I get executed every 4 seconds!", chrono::Utc::now());
+        log("I get executed every 4 seconds!");
     }));
 
     // Create a Send/Receive channel using a String
@@ -23,13 +22,10 @@ fn main() {
     std::thread::Builder::new()
         .name(String::from("channel-receiver"))
         .spawn(move || {
-            println!(
-                "{:?} - Starting channel receiver loop within thread",
-                chrono::Utc::now()
-            );
+            log("Starting channel receiver loop within thread");
             loop {
                 if let Ok(msg) = rx.recv() {
-                    println!("{:?} - rx: {msg}", chrono::Utc::now());
+                    log(&format!("rx: {msg}"));
                 }
                 std::thread::sleep(Duration::from_millis(500));
             }
@@ -37,10 +33,10 @@ fn main() {
         .expect("Error spawning channel-receiver thread");
 
     // Create a job which sends a message via the channel
-    sched.add(Job::new("*/5 * * * * *".parse().unwrap(), {
+    sched.add(Job::new("0/5 * * * * *".parse().unwrap(), {
         move || {
             tx.send(String::from(
-                "I get executed every 5 seconds and send an mpsc!",
+                "I get executed every 5th second and send an mpsc!",
             ))
             .unwrap();
         }
@@ -49,10 +45,7 @@ fn main() {
     std::thread::Builder::new()
         .name(String::from("job-scheduler"))
         .spawn(move || {
-            println!(
-                "{:?} - Starting job scheduler loop within thread",
-                chrono::Utc::now()
-            );
+            log("Starting job scheduler loop within thread");
             loop {
                 sched.tick();
                 std::thread::sleep(Duration::from_millis(500));
@@ -60,9 +53,16 @@ fn main() {
         })
         .expect("Error spawning job-scheduler thread");
 
-    let wait_seconds: u64 = 40;
-    println!("Waiting for {wait_seconds} seconds!");
-    std::thread::sleep(Duration::from_secs(wait_seconds));
-    println!("Finished. Goodby!");
+    log(&format!("Run for about {WAIT_SECONDS} seconds!"));
+    std::thread::sleep(Duration::from_secs(WAIT_SECONDS));
+    log("Finished. Goodby!");
     std::process::exit(0);
+}
+
+fn log(msg: &str) {
+    println!(
+        "{:?} - {:?} - {msg}",
+        chrono::Utc::now(),
+        std::thread::current().id()
+    );
 }

--- a/examples/simple_job_thread.rs
+++ b/examples/simple_job_thread.rs
@@ -1,24 +1,23 @@
+use core::time::Duration;
 use job_scheduler_ng::{Job, JobScheduler};
-use std::time::Duration;
 
 fn main() {
+    const WAIT_SECONDS: u64 = 40;
+
     let mut sched = JobScheduler::new();
 
-    sched.add(Job::new("1/10 * * * * *".parse().unwrap(), || {
-        println!(
-            "{:?} - I get executed every 10 seconds!",
-            chrono::Utc::now()
-        );
+    sched.add(Job::new("0/10 * * * * *".parse().unwrap(), || {
+        log("I get executed every 10th second!");
     }));
 
     sched.add(Job::new("*/4 * * * * *".parse().unwrap(), || {
-        println!("{:?} - I get executed every 4 seconds!", chrono::Utc::now());
+        log("I get executed every 4 seconds!");
     }));
 
     std::thread::Builder::new()
         .name(String::from("job-scheduler"))
         .spawn(move || {
-            println!("{:?} - Starting loop within thread", chrono::Utc::now());
+            log("Starting loop within thread");
             loop {
                 sched.tick();
                 std::thread::sleep(Duration::from_millis(500));
@@ -26,9 +25,16 @@ fn main() {
         })
         .expect("Error spawning job-scheduler thread");
 
-    let wait_seconds: u64 = 40;
-    println!("Waiting for {wait_seconds} seconds!");
-    std::thread::sleep(Duration::from_secs(wait_seconds));
-    println!("Finished. Goodby!");
+    log(&format!("Run for about {WAIT_SECONDS} seconds!"));
+    std::thread::sleep(Duration::from_secs(WAIT_SECONDS));
+    log("Finished. Goodby!");
     std::process::exit(0);
+}
+
+fn log(msg: &str) {
+    println!(
+        "{:?} - {:?} - {msg}",
+        chrono::Utc::now(),
+        std::thread::current().id()
+    );
 }

--- a/examples/simple_job_tokio.rs
+++ b/examples/simple_job_tokio.rs
@@ -1,19 +1,21 @@
+use core::time::Duration;
 use job_scheduler_ng::{Job, JobScheduler};
-use std::time::Duration;
+use std::hash::{DefaultHasher, Hash, Hasher};
 
 #[tokio::main]
 async fn main() {
-    println!("Initializing scheduler!");
-    init_scheduler().await;
+    const WAIT_SECONDS: u64 = 40;
 
-    let wait_seconds: u64 = 40;
-    println!("Waiting for {wait_seconds} seconds!");
-    tokio::time::sleep(Duration::from_secs(wait_seconds)).await;
-    println!("Finished. Goodby!");
+    log("Initializing scheduler!");
+    init_scheduler();
+
+    log(&format!("Run for about {WAIT_SECONDS} seconds!"));
+    tokio::time::sleep(Duration::from_secs(WAIT_SECONDS)).await;
+    log("Finished. Goodby!");
     std::process::exit(0);
 }
 
-async fn init_scheduler() {
+fn init_scheduler() {
     // Start a new runtime to not mess with the current running one
     let runtime = tokio::runtime::Runtime::new().unwrap();
 
@@ -24,18 +26,15 @@ async fn init_scheduler() {
 
             let mut sched = JobScheduler::new();
 
-            sched.add(Job::new("1/10 * * * * *".parse().unwrap(), || {
-                println!(
-                    "{:?} - I get executed every 10 seconds!",
-                    chrono::Utc::now()
-                );
+            sched.add(Job::new("0/10 * * * * *".parse().unwrap(), || {
+                log("I get executed every 10th second!");
             }));
 
             sched.add(Job::new("*/4 * * * * *".parse().unwrap(), || {
-                println!("{:?} - I get executed every 4 seconds!", chrono::Utc::now());
+                log("I get executed every 4 seconds!");
             }));
 
-            sched.add(Job::new("*/5 * * * * *".parse().unwrap(), || {
+            sched.add(Job::new("0/5 * * * * *".parse().unwrap(), || {
                 runtime.spawn(test_job_every_five());
             }));
 
@@ -43,7 +42,7 @@ async fn init_scheduler() {
                 runtime.spawn(test_job_every_eight());
             }));
 
-            println!("{:?} - Starting loop", chrono::Utc::now());
+            log("Starting loop");
             loop {
                 sched.tick();
                 runtime.block_on(async move {
@@ -55,19 +54,32 @@ async fn init_scheduler() {
 }
 
 async fn test_job_every_five() {
-    println!(
-        "{:?} - I get executed every 5 seconds (begin)!",
-        chrono::Utc::now()
-    );
-    // Wait 6 seconds, this will demonstrate this call will be async and not blocking.
-    tokio::time::sleep(Duration::from_secs(6)).await;
-    println!(
-        "{:?} - I get executed every 5 seconds (end)!",
-        chrono::Utc::now()
-    );
+    let hash = hash(&chrono::Utc::now().timestamp_millis());
+    log(&format!(
+        "I get executed every 5th second (begin - {hash})!"
+    ));
+    // Wait 7 seconds, this will demonstrate this call will be async and not blocking.
+    tokio::time::sleep(Duration::from_secs(7)).await;
+    log(&format!(
+        "I get executed every 5th second (end   - {hash})!"
+    ));
 }
 
 async fn test_job_every_eight() {
     tokio::time::sleep(Duration::from_millis(500)).await;
-    println!("{:?} - I get executed every 8 seconds!", chrono::Utc::now());
+    log("I get executed every 8 seconds!");
+}
+
+fn log(msg: &str) {
+    println!(
+        "{:?} - {:?} - {msg}",
+        chrono::Utc::now(),
+        std::thread::current().id()
+    );
+}
+
+fn hash<T: Hash>(t: &T) -> u64 {
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish()
 }


### PR DESCRIPTION
 - Set MSRV to v1.61.0 to match chrono's v0.4.34 MSRV
 - Updated dev dependency of tokio to v1.37.0 or higher
 - Several clippy check added
 - Fixed all clippy reported items
 - Set JobScheduler::new() as `const fn`
 - Updated examples to use a `log` function and always print the current thread id
 - Added a very simple hash to better differentiate the tokio 5th second example
